### PR TITLE
remove debug column from API Log Config

### DIFF
--- a/en/web-interface/system/yeti-ui-system-api_log_configs.rst
+++ b/en/web-interface/system/yeti-ui-system-api_log_configs.rst
@@ -4,13 +4,18 @@
 Api Log Configs
 ~~~~~~~~~~~~~~~
 
-Api Log Configs are used for setting (where necessary) Debug mode for storing records to the :ref:`API Log <api_logs>`.
-You can click on the  "Yes/No" button near the records for changing their state.
+Api Log Configs are used for setting (where necessary) Debug mode for storing additional info to the :ref:`API Log <api_logs>`.
+You can create specific API Log Configs or delete them from Admin UI.
+
+The Api Log Configs is a part of our system that enables the configuration of :ref:`API logging <api_logs>` behavior.
+It defines how API requests and responses are logged and whether debugging information is captured for specific API controllers.
 
 **Api Log Config**'s properties:
 ````````````````````````````````
     Controller
         Controller that will be used for applying of the Debug mode of storing records to the :ref:`API Log <api_logs>` in case of enabling Debug property bellow.
-    Debug
-        In case of enabling this property (by clicking on it) additional fields (Request Body, Response Body, Request Headers, Response Headers) will be stored to the :ref:`API Log <api_logs>` for the Controller above.
 
+Best Practices:
+```````````````
+Use API log configurations rationally to capture logs only for controllers that require detailed logging.
+Regularly review and update API log configurations as your application evolves to maintain an accurate log management strategy.


### PR DESCRIPTION
We have a model `System::ApiLogConfig` that is placed under the System menu group and we remove the `debug` column.
If the controller name exists in table sys.api_log_config it already means that debug mode is enabled for specific controllers.